### PR TITLE
Add jemalloc to get it compiled in the GitHub Actions machine

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,8 @@ DUCKDB_DEPS=$(DUCKDB_DIR)/build/release/third_party/fmt/libduckdb_fmt.a \
 	$(DUCKDB_DIR)/build/release/third_party/yyjson/libduckdb_yyjson.a
 
 DUCKDB_EXT=$(DUCKDB_DIR)/build/release/extension/parquet/libparquet_extension.a \
-	$(DUCKDB_DIR)/build/release/extension/json/libjson_extension.a
+	$(DUCKDB_DIR)/build/release/extension/json/libjson_extension.a \
+	$(DUCKDB_DIR)/build/release/extension/jemalloc/libjemalloc_extension.a 
 
 INC =-I$(DUCKDB_DIR)/src/include
 CXXFLAGS = -std=c++11 -DDUCKDB_DIR=\"$(DUCKDB_DIR)\" -DDUCKDB_AFLPLUSPLUS_DIR=\"$(DUCKDB_AFLPLUSPLUS_DIR)\"


### PR DESCRIPTION
On the GitHub Actions machine the build of `AFLplusplus ` was failing with the [`undefined reference to `duckdb::JemallocExtension`](https://github.com/hmeriann/docker_in_gh/actions/runs/11325720334/job/31493197811#step:7:731).

This PR adds `libejemalloc_extension.a` to the `DUCKDB_EXT` and respective building flag so it could complete the build step, [see this run](https://github.com/hmeriann/docker_in_gh/actions/runs/11328784582/job/31502791106#step:7:716).