### PR TITLE
Fix FileReaderFuzzer.yml for manual runs

### DIFF
--- a/.github/workflows/FileReaderFuzzer.yml
+++ b/.github/workflows/FileReaderFuzzer.yml
@@ -131,7 +131,7 @@ jobs:
       duckdb_aflplusplus_repo: ${{ inputs.duckdb_aflplusplus_repo }}
       duckdb_aflplusplus_ref: ${{ inputs.duckdb_aflplusplus_ref }}
       fuzzer: ${{ matrix.fuzzer }}
-      fuzzTime: ${{ inputs.fuzzTime }}
+      fuzzTime: ${{ fromJSON(inputs.fuzzTime) }}
 
   # debug build used to reproduce issues
   build-duckdb-debug:


### PR DESCRIPTION
Under `workflow_dispatch` numerical inputs are treated as strings for some reasons. Therefore they have to be converted back